### PR TITLE
file_picker working but not on WearOS

### DIFF
--- a/wear_os_bible_ereader/lib/counter/cubit/position_cubit.dart
+++ b/wear_os_bible_ereader/lib/counter/cubit/position_cubit.dart
@@ -56,7 +56,7 @@ class PositionCubit extends Cubit<PositionCubitState> {
   PositionCubit() : super(const PositionCubitState.initial());
 
   Future<void> openBook(String title) async {
-    assert(titleToFilename.containsKey(title), 'Invalid book title');
+    // assert(titleToAssetFilename.containsKey(title), 'Invalid book title');
     emit(
         PositionCubitState(
         title,
@@ -162,7 +162,7 @@ const bibleFilename = 'kjvCh.epub';
 /// https://www.globalgreyebooks.com/book-of-mormon-ebook.html
 const bofmFilename = 'bofmGlobalGrey.epub';
 
-const titleToFilename = {
+const titleToAssetFilename = {
   oldTestament: bibleFilename,
   newTestament: bibleFilename,
   bookOfMormon: bofmFilename,

--- a/wear_os_bible_ereader/lib/counter/view/counter_page.dart
+++ b/wear_os_bible_ereader/lib/counter/view/counter_page.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:epub_view/epub_view.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
@@ -24,33 +27,26 @@ class BookshelfPage extends StatelessWidget {
         children: [
           Text(l10n.libraryAppBarTitle),
           const SizedBox(height: 10),
-          for (final k in titleToFilename.keys)
+          for (final k in titleToAssetFilename.keys)
             ElevatedButton(
               onPressed: () => cubit.openBook(k),
               child: Text(k),
             ),
-          // const CounterText(),
-          // const SizedBox(height: 10),
+          ElevatedButton(
+            onPressed: () async {
+              final result = await FilePicker.platform.pickFiles(
+                type: FileType.custom,
+                allowedExtensions: ['epub'],
+              );
+
+              // The result will be null, if the user aborted the dialog
+              if (result != null) {
+                await cubit.openBook(result.files.first.path!);
+              }
+            },
+            child: const Text('Open file'),
+          ),
         ],
-        // ),
-        // : state.bookIsLoading
-        //     ? const Text('Loading')
-        //     :
-        //     // EpubViewTableOfContents()
-        //     ListView(
-        //         // mainAxisAlignment: MainAxisAlignment.center,
-        //         children: [
-        //           for (final c in cubit.chapters())
-        //             ElevatedButton(
-        //               onPressed: () => cubit.openBook(c),
-        //               child: Text(c),
-        //             ),
-        //           const SizedBox(height: 10),
-        //           Text(l10n.libraryAppBarTitle),
-        //           const CounterText(),
-        //           const SizedBox(height: 10),
-        //         ],
-        //       );
       ),
     );
   }

--- a/wear_os_bible_ereader/pubspec.lock
+++ b/wear_os_bible_ereader/pubspec.lock
@@ -161,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   file:
     dependency: transitive
     description:
@@ -169,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "9d6e95ec73abbd31ec54d0e0df8a961017e165aba1395e462e5b31ea0c165daf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.1"
   flow_builder:
     dependency: "direct main"
     description:
@@ -203,8 +219,21 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "950e77c2bbe1692bc0874fc7fb491b96a4dc340457f4ea1641443d0a6c1ea360"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.15"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -376,6 +405,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   pointycastle:
     dependency: transitive
     description:
@@ -621,6 +658,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "5a751eddf9db89b3e5f9d50c20ab8612296e4e8db69009788d6c8b060a84191c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.4"
   xml:
     dependency: transitive
     description:
@@ -639,4 +684,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.19.0 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=3.3.0"

--- a/wear_os_bible_ereader/pubspec.yaml
+++ b/wear_os_bible_ereader/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   bloc: ^8.1.1
   epub_view: ^3.0.0
   equatable: ^2.0.5
+  file_picker: ^5.3.1
   flow_builder: ^0.0.9
   flutter:
     sdk: flutter


### PR DESCRIPTION
This is a working example of using [file_picker](https://pub.dev/packages/file_picker) Flutter package to use native file picker to open epub files not in assets (for example in `Documents/`).

Unfortunately when running on WearOS emulator, when you try to open the picker there's a pop-up that says `no application can handle this action`

Looks like I'll need to explore https://developer.android.com/training/wearables/data/data-layer more for allowing users to transfer/open arbitrary epub files.